### PR TITLE
Add split_pdf method for PDF document splitting

### DIFF
--- a/src/nutrient_dws/api/direct.py
+++ b/src/nutrient_dws/api/direct.py
@@ -230,6 +230,44 @@ class DirectAPIMixin:
         """
         return self._process_file("apply-redactions", input_file, output_path)
 
+    def split_pdf(
+        self,
+        input_file: FileInput,
+        output_path: Optional[str] = None,
+        page_ranges: Optional[List[str]] = None,
+        split_type: str = "pages",
+    ) -> Optional[bytes]:
+        """Split a PDF into multiple files.
+
+        Splits a PDF document into separate files based on specified criteria.
+        If input is an Office document, it will be converted to PDF first.
+
+        Args:
+            input_file: Input file (PDF or Office document).
+            output_path: Optional path to save the output file.
+            page_ranges: List of page ranges to split (e.g., ["1-3", "4-6", "7"]).
+            split_type: Type of split operation. Options: "pages", "bookmarks".
+
+        Returns:
+            Processed file as bytes, or None if output_path is provided.
+
+        Raises:
+            AuthenticationError: If API key is missing or invalid.
+            APIError: For other API errors.
+            ValueError: If invalid page ranges provided.
+
+        Example:
+            # Split by page ranges
+            client.split_pdf(
+                "document.pdf",
+                page_ranges=["1-5", "6-10", "11-15"]
+            )
+        """
+        options = {"split_type": split_type}
+        if page_ranges is not None:
+            options["page_ranges"] = page_ranges  # type: ignore
+        return self._process_file("split-pdf", input_file, output_path, **options)
+
     def merge_pdfs(
         self,
         input_files: List[FileInput],

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -66,6 +66,7 @@ def test_client_has_direct_api_methods():
     assert hasattr(client, "watermark_pdf")
     assert hasattr(client, "ocr_pdf")
     assert hasattr(client, "apply_redactions")
+    assert hasattr(client, "split_pdf")
     assert hasattr(client, "merge_pdfs")
 
 

--- a/tests/unit/test_direct_api.py
+++ b/tests/unit/test_direct_api.py
@@ -1,0 +1,76 @@
+"""Unit tests for Direct API methods."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nutrient_dws.client import NutrientClient
+
+
+@pytest.fixture
+def mock_client():
+    """Create a mock NutrientClient for testing."""
+    client = NutrientClient(api_key="test-key")
+    client._process_file = MagicMock(return_value=b"mock-result")
+    return client
+
+
+def test_split_pdf_basic(mock_client):
+    """Test basic split_pdf functionality."""
+    result = mock_client.split_pdf("test.pdf")
+
+    # Verify _process_file was called with correct parameters
+    mock_client._process_file.assert_called_once_with(
+        "split-pdf", "test.pdf", None, split_type="pages"
+    )
+    assert result == b"mock-result"
+
+
+def test_split_pdf_with_page_ranges(mock_client):
+    """Test split_pdf with page ranges."""
+    page_ranges = ["1-3", "4-6", "7-10"]
+    result = mock_client.split_pdf("test.pdf", page_ranges=page_ranges, split_type="pages")
+
+    # Verify _process_file was called with correct parameters
+    mock_client._process_file.assert_called_once_with(
+        "split-pdf", "test.pdf", None, split_type="pages", page_ranges=page_ranges
+    )
+    assert result == b"mock-result"
+
+
+def test_split_pdf_with_output_path(mock_client):
+    """Test split_pdf with output path."""
+    mock_client._process_file.return_value = None
+
+    result = mock_client.split_pdf("test.pdf", output_path="output.pdf", split_type="bookmarks")
+
+    # Verify _process_file was called with correct parameters
+    mock_client._process_file.assert_called_once_with(
+        "split-pdf", "test.pdf", "output.pdf", split_type="bookmarks"
+    )
+    assert result is None
+
+
+def test_split_pdf_with_all_parameters(mock_client):
+    """Test split_pdf with all parameters."""
+    page_ranges = ["1-5", "6-10"]
+    mock_client.split_pdf(
+        "test.pdf", output_path="split_output.pdf", page_ranges=page_ranges, split_type="pages"
+    )
+
+    # Verify _process_file was called with correct parameters
+    mock_client._process_file.assert_called_once_with(
+        "split-pdf", "test.pdf", "split_output.pdf", split_type="pages", page_ranges=page_ranges
+    )
+
+
+def test_split_pdf_bytes_input(mock_client):
+    """Test split_pdf with bytes input."""
+    pdf_bytes = b"mock-pdf-content"
+    result = mock_client.split_pdf(pdf_bytes, page_ranges=["1-2", "3-4"])
+
+    # Verify _process_file was called with correct parameters
+    mock_client._process_file.assert_called_once_with(
+        "split-pdf", pdf_bytes, None, split_type="pages", page_ranges=["1-2", "3-4"]
+    )
+    assert result == b"mock-result"


### PR DESCRIPTION
## Summary
- Add `split_pdf` method to `DirectAPIMixin` following the established pattern
- Support splitting PDFs by page ranges or bookmarks
- Comprehensive unit tests for all functionality

## Test plan
- [x] Unit tests for basic split functionality
- [x] Unit tests for page ranges parameter
- [x] Unit tests for output path handling
- [x] Unit tests for different input types (bytes, file paths)
- [x] All existing tests continue to pass
- [x] Type checking passes with mypy
- [x] Linting passes with ruff

🤖 Generated with [Claude Code](https://claude.ai/code)