### PR TITLE
Add delete_pdf_pages method for PDF page deletion

### DIFF
--- a/SUPPORTED_OPERATIONS.md
+++ b/SUPPORTED_OPERATIONS.md
@@ -221,6 +221,41 @@ client.duplicate_pdf_pages(
 )
 ```
 
+### 10. `delete_pdf_pages(input_file, page_indexes, output_path=None)`
+Deletes specific pages from a PDF document.
+
+**Parameters:**
+- `input_file`: PDF file to process
+- `page_indexes`: List of page indexes to delete (0-based). Duplicates are automatically removed.
+- `output_path`: Optional path to save the output file
+
+**Returns:**
+- Processed PDF as bytes, or None if `output_path` provided
+
+**Note:** Negative page indexes are not currently supported.
+
+**Example:**
+```python
+# Delete first and third pages
+result = client.delete_pdf_pages(
+    "document.pdf", 
+    page_indexes=[0, 2]  # Delete pages 1 and 3 (0-based indexing)
+)
+
+# Delete specific pages with duplicates (duplicates ignored)
+result = client.delete_pdf_pages(
+    "document.pdf",
+    page_indexes=[1, 3, 1, 5]  # Effectively deletes pages 2, 4, and 6
+)
+
+# Save to specific file
+client.delete_pdf_pages(
+    "document.pdf",
+    page_indexes=[0, 1],  # Delete first two pages
+    output_path="trimmed_document.pdf"
+)
+```
+
 ## Builder API
 
 The Builder API allows chaining multiple operations. Like the Direct API, it automatically converts Office documents to PDF when needed:

--- a/tests/integration/test_live_api.py
+++ b/tests/integration/test_live_api.py
@@ -214,3 +214,62 @@ class TestLiveAPI:
         """Test duplicate_pdf_pages method with empty page_indexes raises error."""
         with pytest.raises(ValueError, match="page_indexes cannot be empty"):
             client.duplicate_pdf_pages(sample_pdf_path, page_indexes=[])
+
+    def test_delete_pdf_pages_basic(self, client, sample_pdf_path):
+        """Test delete_pdf_pages method with basic page deletion."""
+        # Test deleting first page (assuming sample PDF has at least 2 pages)
+        result = client.delete_pdf_pages(sample_pdf_path, page_indexes=[0])
+
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+        # Verify result is a valid PDF
+        assert_is_pdf(result)
+
+    def test_delete_pdf_pages_multiple(self, client, sample_pdf_path):
+        """Test delete_pdf_pages method with multiple page deletion."""
+        # Test deleting multiple pages
+        result = client.delete_pdf_pages(sample_pdf_path, page_indexes=[0, 2])
+
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+        # Verify result is a valid PDF
+        assert_is_pdf(result)
+
+    def test_delete_pdf_pages_with_output_file(self, client, sample_pdf_path, tmp_path):
+        """Test delete_pdf_pages method saving to output file."""
+        output_path = str(tmp_path / "pages_deleted.pdf")
+
+        # Test deleting pages and saving to file
+        result = client.delete_pdf_pages(sample_pdf_path, page_indexes=[1], output_path=output_path)
+
+        # Should return None when saving to file
+        assert result is None
+
+        # Check that output file was created
+        assert (tmp_path / "pages_deleted.pdf").exists()
+        assert (tmp_path / "pages_deleted.pdf").stat().st_size > 0
+        assert_is_pdf(output_path)
+
+    def test_delete_pdf_pages_negative_indexes_error(self, client, sample_pdf_path):
+        """Test delete_pdf_pages method with negative indexes raises error."""
+        # Currently negative indexes are not supported for deletion
+        with pytest.raises(ValueError, match="Negative page indexes not yet supported"):
+            client.delete_pdf_pages(sample_pdf_path, page_indexes=[-1])
+
+    def test_delete_pdf_pages_empty_indexes_error(self, client, sample_pdf_path):
+        """Test delete_pdf_pages method with empty page_indexes raises error."""
+        with pytest.raises(ValueError, match="page_indexes cannot be empty"):
+            client.delete_pdf_pages(sample_pdf_path, page_indexes=[])
+
+    def test_delete_pdf_pages_duplicate_indexes(self, client, sample_pdf_path):
+        """Test delete_pdf_pages method with duplicate page indexes."""
+        # Test that duplicate indexes are handled correctly (should remove duplicates)
+        result = client.delete_pdf_pages(sample_pdf_path, page_indexes=[0, 0, 1])
+
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+        # Verify result is a valid PDF
+        assert_is_pdf(result)

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -69,6 +69,7 @@ def test_client_has_direct_api_methods():
     assert hasattr(client, "merge_pdfs")
     assert hasattr(client, "split_pdf")
     assert hasattr(client, "duplicate_pdf_pages")
+    assert hasattr(client, "delete_pdf_pages")
 
 
 def test_client_context_manager():


### PR DESCRIPTION
## Summary
- Implements `delete_pdf_pages` method for the Direct API
- Follows established Build API patterns from `split_pdf` and `duplicate_pdf_pages`
- Users specify which pages to delete (0-based indexing), method handles conversion to Build API format
- Includes comprehensive integration tests and documentation

## Test plan
- [x] Add method to `DirectAPIMixin` in `src/nutrient_dws/api/direct.py`
- [x] Add comprehensive integration tests in `tests/integration/test_live_api.py`
- [x] Update unit tests to verify method exists
- [x] Update `SUPPORTED_OPERATIONS.md` with documentation and examples
- [x] Run quality checks (linting, type checking, formatting)
- [x] Test basic page deletion functionality
- [x] Test multiple page deletion
- [x] Test file output handling
- [x] Test duplicate index handling
- [x] Test error cases (empty indexes, negative indexes)

🤖 Generated with [Claude Code](https://claude.ai/code)